### PR TITLE
🐛 Allow spending multiple UTXOs from the same time-locked descriptor (#15)

### DIFF
--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -654,14 +654,18 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface): {
           `Error: could not determine whether this is a segwit descriptor`
         );
       }
+
+      const locktime =
+        psbt.locktime !== this.getLockTime() ? this.getLockTime() : undefined;
+
       return updatePsbt({
         psbt,
         vout,
         ...(txHex !== undefined ? { txHex } : {}),
         ...(txId !== undefined ? { txId } : {}),
         ...(value !== undefined ? { value } : {}),
+        locktime,
         sequence: this.getSequence(),
-        locktime: this.getLockTime(),
         keysInfo: this.#expansionMap ? Object.values(this.#expansionMap) : [],
         scriptPubKey: this.getScriptPubKey(),
         isSegwit,

--- a/src/psbt.ts
+++ b/src/psbt.ts
@@ -207,7 +207,7 @@ export function updatePsbt({
     psbt.setLocktime(locktime);
   }
   let inputSequence;
-  if (locktime !== undefined) {
+  if (locktime !== undefined || psbt.locktime !== 0) {
     if (sequence === undefined) {
       // for CTV nSequence MUST be <= 0xfffffffe otherwise OP_CHECKLOCKTIMEVERIFY will fail.
       inputSequence = 0xfffffffe;


### PR DESCRIPTION
This relates to #15