### PR TITLE
feat: Improve React Native compatibility and bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-10-12
+
+### Changed
+
+- **React Native Compatibility**:
+  - Adjusted the way the library imports `ledger-bitcoin` in `src/ledger.ts` to improve compatibility with React Native projects using the Metro bundler.
+    - Previously, the library utilized dynamic imports (`await import('ledger-bitcoin')`), but this approach caused issues with Metro bundler. The bundler tried to unconditionally require `ledger-bitcoin` even if it wasn't installed (since it's an optional peerDependency).
+    - The new approach bypasses this by using a direct `require` statement. For more details on the underlying issue, refer to [this React Native discussion](https://github.com/react-native-community/discussions-and-proposals/issues/120).
+    - This update ensures smoother integration for developers using this library in React Native projects.
+
 ## [1.1.0] - 2023-10-7
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/descriptors",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/descriptors",
-      "version": "1.0.3",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/descriptors",
   "description": "This library parses and creates Bitcoin Miniscript Descriptors and generates Partially Signed Bitcoin Transactions (PSBTs). It provides PSBT finalizers and signers for single-signature, BIP32 and Hardware Wallets.",
   "homepage": "https://github.com/bitcoinerlab/descriptors",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "repository": {

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -51,7 +51,22 @@ export async function importAndValidateLedgerBitcoin(
 ): Promise<unknown> {
   let ledgerBitcoinModule;
   try {
-    ledgerBitcoinModule = await import('ledger-bitcoin');
+    // Originally, the code used dynamic imports:
+    // ledgerBitcoinModule = await import('ledger-bitcoin');
+
+    // However, in React Native with the Metro bundler, there's an issue with
+    // recognizing dynamic imports inside try-catch blocks. For details, refer to:
+    // https://github.com/react-native-community/discussions-and-proposals/issues/120
+
+    // The dynamic import gets transpiled to:
+    // ledgerBitcoinModule = Promise.resolve().then(() => __importStar(require('ledger-bitcoin')));
+
+    // Metro bundler fails to recognize the above as conditional. Hence, it tries
+    // to require 'ledger-bitcoin' unconditionally, leading to potential errors if
+    // 'ledger-bitcoin' is not installed (given it's an optional peerDependency).
+
+    // To bypass this, we directly use require:
+    ledgerBitcoinModule = require('ledger-bitcoin');
   } catch (error) {
     throw new Error(
       'Could not import "ledger-bitcoin". This is a peer dependency and needs to be installed explicitly. Please run "npm install ledger-bitcoin" to use Ledger Hardware Wallet functionality.'


### PR DESCRIPTION
- **src/ledger.ts**: Updated the method of importing `ledger-bitcoin` to improve compatibility with React Native's Metro bundler. Replaced the dynamic import (`await import('ledger-bitcoin')`) with a direct `require` statement to mitigate bundler issues.

- **package.json & package-lock.json**: Bumped the version from 1.1.0 to 1.1.1 to reflect the improvements.

- **CHANGELOG.md**: Documented the changes made for version 1.1.1, highlighting the adjustment in importing `ledger-bitcoin` for React Native compatibility.

Reference for the Metro bundler issue: https://github.com/react-native-community/discussions-and-proposals/issues/120