### PR TITLE
Issue 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Descriptor Buffer Comparison**:
+  - Addressed a bug related to buffer comparisons in `src/descriptors.ts`.
+    - Modified the comparison logic for `witnessScript` and `redeemScript` to handle cases where one of the buffers may be `undefined`.
+    - Introduced the `eqBuffers` function to compare two buffers, ensuring that it correctly handles `undefined` values.
+    - This fix ensures accurate and error-free descriptor comparisons, particularly crucial for finalizing psbt indexes.
+    - Refer to [issue-20](https://github.com/bitcoinerlab/descriptors/issues/20) for more details.
+
 ## [1.1.1] - 2023-10-12
 
 ### Changed

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -765,12 +765,16 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       let sequence = this.getSequence();
       if (sequence === undefined && locktime !== 0) sequence = 0xfffffffe;
       if (sequence === undefined && locktime === 0) sequence = 0xffffffff;
+      const eqBuffers = (buf1: Buffer | undefined, buf2: Buffer | undefined) =>
+        buf1 instanceof Buffer && buf2 instanceof Buffer
+          ? Buffer.compare(buf1, buf2) === 0
+          : buf1 === buf2;
       if (
         Buffer.compare(scriptPubKey, this.getScriptPubKey()) !== 0 ||
         sequence !== inputSequence ||
         locktime !== psbt.locktime ||
-        this.getWitnessScript() !== input.witnessScript ||
-        this.getRedeemScript() !== input.redeemScript
+        !eqBuffers(this.getWitnessScript(), input.witnessScript) ||
+        !eqBuffers(this.getRedeemScript(), input.redeemScript)
       ) {
         throw new Error(
           `Error: cannot finalize psbt index ${index} since it does not correspond to this descriptor`


### PR DESCRIPTION
**Buffer Comparison in `#assertPsbtInput`**:
Addressed a bug related to buffer comparisons in `src/descriptors.ts`.
- Modified the comparison logic for `witnessScript` and `redeemScript`.
- Introduced the `eqBuffers` function to compare two buffers, ensuring that it correctly handles `undefined` values.
- Refer to [issue-20](https://github.com/bitcoinerlab/descriptors/issues/20) for more details.