### PR TITLE
Add tr(KEY) support

### DIFF
--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -410,6 +410,26 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
         payment = p2wpkh({ pubkey, network });
       }
     }
+    //tr(KEY) - taproot
+    else if (canonicalExpression.match(RE.rePtrAnchored)) {
+      isSegwit = true;
+      const keyExpression = canonicalExpression.match(RE.reKeyExp)?.[0];
+      if (!keyExpression)
+        throw new Error(`Error: keyExpression could not me extracted`);
+      if (canonicalExpression !== `tr(${keyExpression})`)
+        throw new Error(`Error: invalid expression ${expression}`);
+      expandedExpression = 'tr(@0)';
+      const pKE = parseKeyExpression({ keyExpression, network, isSegwit });
+      expansionMap = { '@0': pKE };
+      if (!isCanonicalRanged) {
+        const pubkey = pKE.pubkey;
+        if (!pubkey)
+          throw new Error(
+            `Error: could not extract a pubkey from ${expression}`
+          );
+        payment = p2tr({ pubkey, network });
+      }
+    }
     //sh(wsh(miniscript))
     else if (canonicalExpression.match(RE.reShWshMiniscriptAnchored)) {
       isSegwit = true;

--- a/src/re.ts
+++ b/src/re.ts
@@ -54,6 +54,8 @@ const reAddr = String.raw`addr\((.*?)\)`; //Matches anything. We assert later in
 const rePkh = String.raw`pkh\(${reKeyExp}\)`;
 const reWpkh = String.raw`wpkh\(${reKeyExp}\)`;
 const reShWpkh = String.raw`sh\(wpkh\(${reKeyExp}\)\)`;
+const rePtr = String.raw`tr\(${reKeyExp}\)`;
+
 
 const reMiniscript = String.raw`(.*?)`; //Matches anything. We assert later in the code that miniscripts are valid and sane.
 
@@ -72,6 +74,7 @@ export const reAddrAnchored = anchorStartAndEnd(composeChecksum(reAddr));
 export const rePkhAnchored = anchorStartAndEnd(composeChecksum(rePkh));
 export const reWpkhAnchored = anchorStartAndEnd(composeChecksum(reWpkh));
 export const reShWpkhAnchored = anchorStartAndEnd(composeChecksum(reShWpkh));
+export const rePtrAnchored = anchorStartAndEnd(composeChecksum(rePtr));
 
 export const reShMiniscriptAnchored = anchorStartAndEnd(
   composeChecksum(makeReSh(reMiniscript))


### PR DESCRIPTION
For brief context, I have been using this library for work with descriptors in a separate ts-based project, and I noticed it didn't handle parsing single-key taproot descriptors `tr(KEY).`

This PR adds support for parsing single-key taproot descriptors (i.e., `tr(KEY)`). I've used the existing p2tr and regex pattern definitions. Happy to make any adjustments to fit the repo code style or any other related changes.
