### PR TITLE
Add getScriptSatisfactionSize function and fix signature size in getTimeConstraints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/descriptors",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/descriptors",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/descriptors",
   "description": "This library parses and creates Bitcoin Miniscript Descriptors and generates Partially Signed Bitcoin Transactions (PSBTs). It provides PSBT finalizers and signers for single-signature, BIP32 and Hardware Wallets.",
   "homepage": "https://github.com/bitcoinerlab/descriptors",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Implemented the `getScriptSatisfactionSize` function to calculate the byte length of script satisfaction for Miniscript-based descriptors, especially useful in coin selection algorithms where signatures are not yet available. The function accounts for a standard signature length of 72 bytes, aligning with the common worst-case scenario in Bitcoin transactions.

- Corrected the signature size assumption in `getTimeConstraints` from 64 bytes to 72 bytes, based on typical DER-encoded ECDSA signature lengths in Bitcoin scripts. This update ensures more accurate handling of signature sizes, though this was not affecting results.

- Updated package version to 2.0.2 to reflect these changes and improvements.