### PR TITLE
Update library to v2.0.3: Ready for Coinselector Algorithm Integration and Enhanced Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ const wpkhOutput = new Output({
 });
 ```
 
-Refer to [the API](https://bitcoinerlab.com/modules/descriptors/api/classes/_Internal_.Output.html#constructor) for the complete list of parameters in the constructor.
+For miniscript-based descriptors, the `signersPubKeys` parameter in the constuctor becomes particularly important. It specifies the spending path of a previous output with multiple spending paths. Detailed information about the constructor parameters, including `signersPubKeys`, can be found in [the API documentation](https://bitcoinerlab.com/modules/descriptors/api/classes/_Internal_.Output.html#constructor) and in [this Stack Exchange answer](https://bitcoin.stackexchange.com/a/118036/89665).
 
 The `Output` class [offers various helpful methods](https://bitcoinerlab.com/modules/descriptors/api/classes/_Internal_.Output.html), including `getAddress()`, which returns the address associated with the descriptor, `getScriptPubKey()`, which returns the `scriptPubKey` for the descriptor, `expand()`, which decomposes a descriptor into its elemental parts, `updatePsbtAsInput()` and `updatePsbtAsOutput()`.
 
-The `updatePsbtAsInput()` method is an essential part of the library, responsible for adding an input to the PSBT corresponding to the UTXO  described by the descriptor. Additionally, when the descriptor expresses an absolute time-spending condition, such as "This UTXO can only be spent after block N," `updatePsbtAsInput()` adds timelock information to the PSBT.
+The `updatePsbtAsInput()` method is an essential part of the library, responsible for adding an input to the PSBT corresponding to the UTXO  described by the descriptor. Additionally, when the descriptor expresses an absolute time-spending condition, such as "This UTXO can only be spent after block N", `updatePsbtAsInput()` adds timelock information to the PSBT.
 
 To call `updatePsbtAsInput()`, use the following syntax:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/descriptors",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/descriptors",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/descriptors",
   "description": "This library parses and creates Bitcoin Miniscript Descriptors and generates Partially Signed Bitcoin Transactions (PSBTs). It provides PSBT finalizers and signers for single-signature, BIP32 and Hardware Wallets.",
   "homepage": "https://github.com/bitcoinerlab/descriptors",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "repository": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,13 +12,15 @@ import type { Payment, Network } from 'bitcoinjs-lib';
  */
 export type Preimage = {
   /**
-   * Use same expressions as in miniscript. For example: "sha256(cdabb7f2dce7bfbd8a0b9570c6fd1e712e5d64045e9d6b517b3d5072251dc204)" or "ripemd160(095ff41131e5946f3c85f79e44adbcf8e27e080e)"
+   * Use same string expressions as in miniscript. For example: "sha256(cdabb7f2dce7bfbd8a0b9570c6fd1e712e5d64045e9d6b517b3d5072251dc204)" or "ripemd160(095ff41131e5946f3c85f79e44adbcf8e27e080e)"
+   *
    * Accepted functions: sha256, hash256, ripemd160, hash160
+   *
    * Digests must be: 64-character HEX for sha256, hash160 or 30-character HEX for ripemd160 or hash160.
    */
   digest: string;
   /**
-   * Hex encoded preimate. Preimages are always 32 bytes (so, 64 character in hex).
+   * Hex encoded preimage. Preimages are always 32 bytes (so, 64 character in hex).
    */
   preimage: string;
 };


### PR DESCRIPTION
This version updates the library to facilitate its use with external coinselector algorithms. The major change involves the library now returning the script satisfaction itself, instead of its size. This is particularly useful in scenarios where actual signatures are not available, as it allows the use of 72-byte zero-padded signatures (marked as 'DANGEROUSLY_USE_FAKE_SIGNATURES'). This feature should be utilized primarily for tx size estimation purposes and testing, and it's essential to be cautious with its application in real transactions.

Key Changes:
- Adapted `signatures` parameter to support 'DANGEROUSLY_USE_FAKE_SIGNATURES', enabling the generation of script satisfactions with 72-byte zero-padded signatures.
- Enhanced documentation to highlight the critical role of the `signersPubKeys` parameter in miniscript-based descriptors, especially for determining spending paths in previous outputs with various spending options.
- Included explicit warnings and guidance on the use of 'DANGEROUSLY_USE_FAKE_SIGNATURES' to prevent misuse in actual transaction scenarios.
- Comprehensive documentation updates for improved clarity and usability, including modifications to README.md and in-code comments.

These updates are designed to make the library more compatible and ready for use with coinselector algorithms, providing a more adaptable and efficient tool for Bitcoin transaction preparation and analysis.

Version: 2.0.3
Author: Jose-Luis Landabaso