### PR TITLE
Add support for single-key tr(KEY) and addr(TAPROOT_ADDRESS) descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ webdocs/
 test/**/*.js
 test/**/*.d.ts
 !test/tools/generateBitcoinCoreFixtures.js
+.aider*

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ For miniscript-based descriptors, the `signersPubKeys` parameter in the constuct
 
 The `Output` class [offers various helpful methods](https://bitcoinerlab.com/modules/descriptors/api/classes/_Internal_.Output.html), including `getAddress()`, which returns the address associated with the descriptor, `getScriptPubKey()`, which returns the `scriptPubKey` for the descriptor, `expand()`, which decomposes a descriptor into its elemental parts, `updatePsbtAsInput()` and `updatePsbtAsOutput()`.
 
+ The library supports a wide range of descriptor types, including:
+ - Pay-to-Public-Key-Hash (P2PKH): `pkh(KEY)`
+ - Pay-to-Witness-Public-Key-Hash (P2WPKH): `wpkh(KEY)`
+ - Pay-to-Script-Hash (P2SH): `sh(SCRIPT)`
+ - Pay-to-Witness-Script-Hash (P2WSH): `wsh(SCRIPT)`
+ - Pay-to-Taproot (P2TR) with single key: `tr(KEY)`
+ - Address-based descriptors: `addr(ADDRESS)`, including Taproot addresses
+
+ These descriptors can be used with various key expressions, including raw public keys, BIP32 derivation paths, and more.
+
 The `updatePsbtAsInput()` method is an essential part of the library, responsible for adding an input to the PSBT corresponding to the UTXO  described by the descriptor. Additionally, when the descriptor expresses an absolute time-spending condition, such as "This UTXO can only be spent after block N", `updatePsbtAsInput()` adds timelock information to the PSBT.
 
 To call `updatePsbtAsInput()`, use the following syntax:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/descriptors",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/descriptors",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/descriptors",
   "description": "This library parses and creates Bitcoin Miniscript Descriptors and generates Partially Signed Bitcoin Transactions (PSBTs). It provides PSBT finalizers and signers for single-signature, BIP32 and Hardware Wallets.",
   "homepage": "https://github.com/bitcoinerlab/descriptors",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "repository": {

--- a/src/applyPR2137.ts
+++ b/src/applyPR2137.ts
@@ -1,0 +1,200 @@
+//While this PR is not merged: https://github.com/bitcoinjs/bitcoinjs-lib/pull/2137
+//The Async functions have not been "fixed"
+import type { Psbt, Signer } from 'bitcoinjs-lib';
+import { checkForInput } from 'bip174/src/lib/utils';
+import type { SignerAsync } from 'ecpair';
+import type { PsbtInput } from 'bip174/src/lib/interfaces';
+import { tapTweakHash } from 'bitcoinjs-lib/src/payments/bip341';
+import { isTaprootInput } from 'bitcoinjs-lib/src/psbt/bip371';
+import { taggedHash } from 'bitcoinjs-lib/src/crypto';
+
+interface HDSignerBase {
+  /**
+   * DER format compressed publicKey buffer
+   */
+  publicKey: Buffer;
+  /**
+   * The first 4 bytes of the sha256-ripemd160 of the publicKey
+   */
+  fingerprint: Buffer;
+}
+interface HDSigner extends HDSignerBase {
+  /**
+   * The path string must match /^m(\/\d+'?)+$/
+   * ex. m/44'/0'/0'/1/23 levels with ' must be hard derivations
+   */
+  derivePath(path: string): HDSigner;
+  /**
+   * Input hash (the "message digest") for the signature algorithm
+   * Return a 64 byte signature (32 byte r and 32 byte s in that order)
+   */
+  sign(hash: Buffer): Buffer;
+  /**
+   * Adjusts a keypair for Taproot payments by applying a tweak to derive the internal key.
+   *
+   * In Taproot, a keypair may need to be tweaked to produce an internal key that conforms to the Taproot script.
+   * This tweak process involves modifying the original keypair based on a specific tweak value to ensure compatibility
+   * with the Taproot address format and functionality.
+   */
+  tweak(t: Buffer): Signer;
+}
+interface HDSignerAsync extends HDSignerBase {
+  derivePath(path: string): HDSignerAsync;
+  sign(hash: Buffer): Promise<Buffer>;
+  tweak(t: Buffer): Signer;
+}
+
+const toXOnly = (pubKey: Buffer) =>
+  pubKey.length === 32 ? pubKey : pubKey.slice(1, 33);
+
+function range(n: number): number[] {
+  return [...Array(n).keys()];
+}
+
+function tapBranchHash(a: Buffer, b: Buffer): Buffer {
+  return taggedHash('TapBranch', Buffer.concat([a, b]));
+}
+
+function calculateScriptTreeMerkleRoot(
+  leafHashes: Buffer[]
+): Buffer | undefined {
+  if (!leafHashes || leafHashes.length === 0) {
+    return undefined;
+  }
+
+  // sort the leaf nodes
+  leafHashes.sort(Buffer.compare);
+
+  // create the initial hash node
+  let currentLevel = leafHashes;
+
+  // build Merkle Tree
+  while (currentLevel.length > 1) {
+    const nextLevel = [];
+    for (let i = 0; i < currentLevel.length; i += 2) {
+      const left = currentLevel[i];
+      const right = i + 1 < currentLevel.length ? currentLevel[i + 1] : left;
+      nextLevel.push(
+        i + 1 < currentLevel.length ? tapBranchHash(left!, right!) : left
+      );
+    }
+    currentLevel = nextLevel as Buffer[];
+  }
+
+  return currentLevel[0];
+}
+
+function getTweakSignersFromHD(
+  inputIndex: number,
+  inputs: PsbtInput[],
+  hdKeyPair: HDSigner | HDSignerAsync
+): Array<Signer | SignerAsync> {
+  const input = checkForInput(inputs, inputIndex);
+  if (!input.tapBip32Derivation || input.tapBip32Derivation.length === 0) {
+    throw new Error('Need tapBip32Derivation to sign with HD');
+  }
+  const myDerivations = input.tapBip32Derivation
+    .map(bipDv => {
+      if (bipDv.masterFingerprint.equals(hdKeyPair.fingerprint)) {
+        return bipDv;
+      } else {
+        return;
+      }
+    })
+    .filter(v => !!v);
+  if (myDerivations.length === 0) {
+    throw new Error(
+      'Need one tapBip32Derivation masterFingerprint to match the HDSigner fingerprint'
+    );
+  }
+
+  const signers: Array<Signer | SignerAsync> = myDerivations.map(bipDv => {
+    const node = hdKeyPair.derivePath(bipDv!.path);
+    if (!bipDv!.pubkey.equals(toXOnly(node.publicKey))) {
+      throw new Error('pubkey did not match tapBip32Derivation');
+    }
+    const h = calculateScriptTreeMerkleRoot(bipDv!.leafHashes);
+    const tweakValue = tapTweakHash(toXOnly(node.publicKey), h);
+
+    return node.tweak(tweakValue);
+  });
+  return signers;
+}
+function getSignersFromHD(
+  inputIndex: number,
+  inputs: PsbtInput[],
+  hdKeyPair: HDSigner | HDSignerAsync
+): Array<Signer | SignerAsync> {
+  const input = checkForInput(inputs, inputIndex);
+  if (isTaprootInput(input)) {
+    return getTweakSignersFromHD(inputIndex, inputs, hdKeyPair);
+  }
+
+  if (!input.bip32Derivation || input.bip32Derivation.length === 0) {
+    throw new Error('Need bip32Derivation to sign with HD');
+  }
+  const myDerivations = input.bip32Derivation
+    .map(bipDv => {
+      if (bipDv.masterFingerprint.equals(hdKeyPair.fingerprint)) {
+        return bipDv;
+      } else {
+        return;
+      }
+    })
+    .filter(v => !!v);
+  if (myDerivations.length === 0) {
+    throw new Error(
+      'Need one bip32Derivation masterFingerprint to match the HDSigner fingerprint'
+    );
+  }
+  const signers: Array<Signer | SignerAsync> = myDerivations.map(bipDv => {
+    const node = hdKeyPair.derivePath(bipDv!.path);
+    if (!bipDv!.pubkey.equals(node.publicKey)) {
+      throw new Error('pubkey did not match bip32Derivation');
+    }
+    return node;
+  });
+  return signers;
+}
+
+export const applyPR2137 = (psbt: Psbt) => {
+  psbt.signInputHD = function signInputHD(
+    inputIndex: number,
+    hdKeyPair: HDSigner,
+    sighashTypes?: number[]
+  ) {
+    if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
+      throw new Error('Need HDSigner to sign input');
+    }
+    const signers = getSignersFromHD(
+      inputIndex,
+      this.data.inputs,
+      hdKeyPair
+    ) as Signer[];
+    signers.forEach(signer => this.signInput(inputIndex, signer, sighashTypes));
+    return this;
+  };
+
+  psbt.signAllInputsHD = function signAllInputsHD(
+    hdKeyPair: HDSigner,
+    sighashTypes?: number[]
+  ) {
+    if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
+      throw new Error('Need HDSigner to sign input');
+    }
+
+    const results: boolean[] = [];
+    for (const i of range(psbt.data.inputs.length)) {
+      try {
+        psbt.signInputHD(i, hdKeyPair, sighashTypes);
+        results.push(true);
+      } catch (err) {
+        results.push(false);
+      }
+    }
+    if (results.every(v => v === false)) {
+      throw new Error('No inputs were signed');
+    }
+    return psbt;
+  };
+};

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -546,13 +546,24 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       });
       expansionMap = { '@0': pKE };
       if (!isCanonicalRanged) {
-        console.log('TRACE', { pKE });
         const pubkey = pKE.pubkey;
         if (!pubkey)
           throw new Error(
-            `Error: could not extract a pubkey from ${expression}`
+            `Error: could not extract a pubkey from ${descriptor}`
           );
-        payment = p2tr({ pubkey, network });
+        
+        // For Taproot, bitcoinjs-lib expects an x-only pubkey (32 bytes)
+        if (pubkey.length !== 32) {
+          throw new Error(
+            `Error: Taproot requires an x-only pubkey (32 bytes), got ${pubkey.length} bytes`
+          );
+        }
+        
+        // Create p2tr payment with the x-only pubkey
+        payment = p2tr({ 
+          internalPubkey: pubkey, // Use as internal pubkey (no script tree)
+          network 
+        });
       }
     } else {
       throw new Error(`Error: Could not parse descriptor ${descriptor}`);

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -532,7 +532,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
         payment = p2wsh({ redeem: { output: script, network }, network });
       }
     }
-    //tr(KEY) - taproot - tr(KEY,SCRIPT) not yet supported
+    //tr(KEY) - taproot - tr(KEY,TREE) not yet supported
     else if (canonicalExpression.match(RE.reTrInternalAnchored)) {
       isSegwit = true;
       isTaproot = true;

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -307,23 +307,28 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       try {
         payment = p2pkh({ output, network });
         isSegwit = false;
+        isTaproot = false;
       } catch (e) {}
       try {
         payment = p2sh({ output, network });
         // It assumes that an addr(SH_ADDRESS) is always a add(SH_WPKH) address
         isSegwit = true;
+        isTaproot = false;
       } catch (e) {}
       try {
         payment = p2wpkh({ output, network });
         isSegwit = true;
+        isTaproot = false;
       } catch (e) {}
       try {
         payment = p2wsh({ output, network });
         isSegwit = true;
+        isTaproot = false;
       } catch (e) {}
       try {
         payment = p2tr({ output, network });
         isSegwit = true;
+        isTaproot = true;
       } catch (e) {}
       if (!payment) {
         throw new Error(`Error: invalid address ${matchedAddress}`);
@@ -332,6 +337,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //pk(KEY)
     else if (canonicalExpression.match(RE.rePkAnchored)) {
       isSegwit = false;
+      isTaproot = false;
       const keyExpression = canonicalExpression.match(
         RE.reNonSegwitKeyExp
       )?.[0];
@@ -355,6 +361,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //pkh(KEY) - legacy
     else if (canonicalExpression.match(RE.rePkhAnchored)) {
       isSegwit = false;
+      isTaproot = false;
       const keyExpression = canonicalExpression.match(
         RE.reNonSegwitKeyExp
       )?.[0];
@@ -377,6 +384,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //sh(wpkh(KEY)) - nested segwit
     else if (canonicalExpression.match(RE.reShWpkhAnchored)) {
       isSegwit = true;
+      isTaproot = false;
       const keyExpression = canonicalExpression.match(RE.reSegwitKeyExp)?.[0];
       if (!keyExpression)
         throw new Error(`Error: keyExpression could not me extracted`);
@@ -402,6 +410,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //wpkh(KEY) - native segwit
     else if (canonicalExpression.match(RE.reWpkhAnchored)) {
       isSegwit = true;
+      isTaproot = false;
       const keyExpression = canonicalExpression.match(RE.reSegwitKeyExp)?.[0];
       if (!keyExpression)
         throw new Error(`Error: keyExpression could not me extracted`);
@@ -422,6 +431,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //sh(wsh(miniscript))
     else if (canonicalExpression.match(RE.reShWshMiniscriptAnchored)) {
       isSegwit = true;
+      isTaproot = false;
       miniscript = canonicalExpression.match(RE.reShWshMiniscriptAnchored)?.[1]; //[1]-> whatever is found sh(wsh(->HERE<-))
       if (!miniscript)
         throw new Error(`Error: could not get miniscript in ${descriptor}`);
@@ -462,6 +472,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       //isSegwit false because we know it's a P2SH of a miniscript and not a
       //P2SH that embeds a witness payment.
       isSegwit = false;
+      isTaproot = false;
       miniscript = canonicalExpression.match(RE.reShMiniscriptAnchored)?.[1]; //[1]-> whatever is found sh(->HERE<-)
       if (!miniscript)
         throw new Error(`Error: could not get miniscript in ${descriptor}`);
@@ -505,6 +516,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //wsh(miniscript)
     else if (canonicalExpression.match(RE.reWshMiniscriptAnchored)) {
       isSegwit = true;
+      isTaproot = false;
       miniscript = canonicalExpression.match(RE.reWshMiniscriptAnchored)?.[1]; //[1]-> whatever is found wsh(->HERE<-)
       if (!miniscript)
         throw new Error(`Error: could not get miniscript in ${descriptor}`);

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -558,7 +558,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       }
     }
     //tr(KEY) - taproot - TODO: tr(KEY,TREE) not yet supported
-    else if (canonicalExpression.match(RE.reTrInternalAnchored)) {
+    else if (canonicalExpression.match(RE.reTrSingleKeyAnchored)) {
       isSegwit = true;
       isTaproot = true;
       const keyExpression = canonicalExpression.match(RE.reTaprootKeyExp)?.[0];

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -1024,20 +1024,18 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     }
 
     /**
-     * Returns the tuple: `{ isPKH: boolean; isWPKH: boolean; isSH: boolean; }`
-     * for this Output.
-     */
-    /**
-     * Attempts to determine the type of output script by testing it against various payment types.
-     * 
+     * Attempts to determine the type of output script by testing it against
+     * various payment types.
+     *
      * This method tries to identify if the output is one of the following types:
      * - P2SH (Pay to Script Hash)
      * - P2WSH (Pay to Witness Script Hash)
      * - P2WPKH (Pay to Witness Public Key Hash)
      * - P2PKH (Pay to Public Key Hash)
      * - P2TR (Pay to Taproot)
-     * 
-     * @returns An object with boolean properties indicating the detected output type
+     *
+     * @returns An object { isPKH: boolean; isWPKH: boolean; isSH: boolean; isWSH: boolean; isTR: boolean;}
+     * with boolean properties indicating the detected output type
      */
     guessOutput() {
       function guessSH(output: Buffer) {

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -1036,6 +1036,14 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
           return false;
         }
       }
+      function guessWSH(output: Buffer) {
+        try {
+          payments.p2wsh({ output });
+          return true;
+        } catch (err) {
+          return false;
+        }
+      }
       function guessWPKH(output: Buffer) {
         try {
           payments.p2wpkh({ output });
@@ -1052,14 +1060,24 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
           return false;
         }
       }
+      function guessTR(output: Buffer) {
+        try {
+          payments.p2tr({ output });
+          return true;
+        } catch (err) {
+          return false;
+        }
+      }
       const isPKH = guessPKH(this.getScriptPubKey());
       const isWPKH = guessWPKH(this.getScriptPubKey());
       const isSH = guessSH(this.getScriptPubKey());
+      const isWSH = guessWSH(this.getScriptPubKey());
+      const isTR = guessTR(this.getScriptPubKey());
 
-      if ([isPKH, isWPKH, isSH].filter(Boolean).length > 1)
+      if ([isPKH, isWPKH, isSH, isWSH, isTR].filter(Boolean).length > 1)
         throw new Error('Cannot have multiple output types.');
 
-      return { isPKH, isWPKH, isSH };
+      return { isPKH, isWPKH, isSH, isWSH, isTR };
     }
 
     // References for inputWeight & outputWeight:

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -621,6 +621,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
     //isSegwit true if witnesses are needed to the spend coins sent to this descriptor.
     //may be unset because we may get addr(P2SH) which we don't know if they have segwit.
     readonly #isSegwit?: boolean;
+    readonly #isTaproot?: boolean;
     readonly #expandedExpression?: string;
     readonly #expandedMiniscript?: string;
     readonly #expansionMap?: ExpansionMap;
@@ -729,6 +730,8 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
         this.#expansionMap = expandedResult.expansionMap;
       if (expandedResult.isSegwit !== undefined)
         this.#isSegwit = expandedResult.isSegwit;
+      if (expandedResult.isTaproot !== undefined)
+        this.#isTaproot = expandedResult.isTaproot;
       if (expandedResult.expandedMiniscript !== undefined)
         this.#expandedMiniscript = expandedResult.expandedMiniscript;
       if (expandedResult.redeemScript !== undefined)
@@ -980,6 +983,13 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
      */
     isSegwit(): boolean | undefined {
       return this.#isSegwit;
+    }
+
+    /**
+     * Whether this `Output` is Taproot.
+     */
+    isTaproot(): boolean | undefined {
+      return this.#isTaproot;
     }
 
     /**
@@ -1273,6 +1283,13 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
           `Error: could not determine whether this is a segwit descriptor`
         );
       }
+      const isTaproot = this.isTaproot();
+      if (isTaproot === undefined) {
+        //This should only happen when using addr() expressions
+        throw new Error(
+          `Error: could not determine whether this is a taproot descriptor`
+        );
+      }
       const index = updatePsbt({
         psbt,
         vout,
@@ -1284,6 +1301,7 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
         keysInfo: this.#expansionMap ? Object.values(this.#expansionMap) : [],
         scriptPubKey: this.getScriptPubKey(),
         isSegwit,
+        isTaproot,
         witnessScript: this.getWitnessScript(),
         redeemScript: this.getRedeemScript(),
         rbf

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -1007,7 +1007,8 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
      *
      * *NOTE:* When the descriptor in an input is `addr(address)`, it is assumed
      * that any `addr(SH_TYPE_ADDRESS)` is in fact a Segwit `SH_WPKH`
-     * (Script Hash-Witness Public Key Hash).
+     * (Script Hash-Witness Public Key Hash), and any `addr(TR_TYPE_ADDRESS)` 
+     * is a single key Taproot address (like those defined in BIP86).
      * For inputs using arbitrary scripts (not standard addresses),
      * use a descriptor in the format `sh(MINISCRIPT)`.
      *

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -1027,6 +1027,18 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
      * Returns the tuple: `{ isPKH: boolean; isWPKH: boolean; isSH: boolean; }`
      * for this Output.
      */
+    /**
+     * Attempts to determine the type of output script by testing it against various payment types.
+     * 
+     * This method tries to identify if the output is one of the following types:
+     * - P2SH (Pay to Script Hash)
+     * - P2WSH (Pay to Witness Script Hash)
+     * - P2WPKH (Pay to Witness Public Key Hash)
+     * - P2PKH (Pay to Public Key Hash)
+     * - P2TR (Pay to Taproot)
+     * 
+     * @returns An object with boolean properties indicating the detected output type
+     */
     guessOutput() {
       function guessSH(output: Buffer) {
         try {

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -1135,8 +1135,9 @@ export function DescriptorsFactory(ecc: TinySecp256k1Interface) {
       //expand any miniscript-based descriptor. If not miniscript-based, then it's
       //an addr() descriptor. For those, we can only guess their type.
       const expansion = this.expand().expandedExpression;
-      const { isPKH, isWPKH, isSH } = this.guessOutput();
-      if (!expansion && !isPKH && !isWPKH && !isSH) throw new Error(errorMsg);
+      const { isPKH, isWPKH, isSH, isTR } = this.guessOutput();
+      if (!expansion && !isPKH && !isWPKH && !isSH && !isTR)
+        throw new Error(errorMsg);
 
       const firstSignature =
         signatures && typeof signatures[0] === 'object'

--- a/src/keyExpressions.ts
+++ b/src/keyExpressions.ts
@@ -50,6 +50,7 @@ const derivePath = (node: BIP32Interface, path: string) => {
 export function parseKeyExpression({
   keyExpression,
   isSegwit,
+  isTaproot,
   ECPair,
   BIP32,
   network = networks.bitcoin
@@ -63,6 +64,13 @@ export function parseKeyExpression({
    * expression) is compressed (33 bytes).
    */
   isSegwit?: boolean;
+  /**
+   * Indicates if this key expression belongs to a Taproot output. For Taproot,
+   * the key must be represented as an x-only public key (32 bytes).
+   * If a 33-byte compressed pubkey is derived, it is converted to its x-only
+   * representation.
+   */
+  isTaproot?: boolean;
   ECPair: ECPairAPI;
   BIP32: BIP32API;
 }): KeyInfo {
@@ -173,6 +181,10 @@ export function parseKeyExpression({
   if (originPath || keyPath) {
     path = `m${originPath ?? ''}${keyPath ?? ''}`;
   }
+  if (pubkey !== undefined && isTaproot && pubkey.length === 33)
+    // If we get a 33-byte compressed key, drop the first byte.
+    pubkey = pubkey.slice(1, 33);
+
   return {
     keyExpression,
     ...(pubkey !== undefined ? { pubkey } : {}),

--- a/src/miniscript.ts
+++ b/src/miniscript.ts
@@ -20,12 +20,14 @@ import type { Preimage, TimeConstraints, ExpansionMap } from './types';
 export function expandMiniscript({
   miniscript,
   isSegwit,
+  isTaproot,
   network = networks.bitcoin,
   ECPair,
   BIP32
 }: {
   miniscript: string;
   isSegwit: boolean;
+  isTaproot: boolean;
   network?: Network;
   ECPair: ECPairAPI;
   BIP32: BIP32API;
@@ -33,9 +35,15 @@ export function expandMiniscript({
   expandedMiniscript: string;
   expansionMap: ExpansionMap;
 } {
+  if (isTaproot) throw new Error('Taproot miniscript not yet supported.');
+  const reKeyExp = isTaproot
+    ? RE.reTaprootKeyExp
+    : isSegwit
+      ? RE.reSegwitKeyExp
+      : RE.reNonSegwitKeyExp;
   const expansionMap: ExpansionMap = {};
   const expandedMiniscript = miniscript.replace(
-    RegExp(RE.reKeyExp, 'g'),
+    RegExp(reKeyExp, 'g'),
     (keyExpression: string) => {
       const key = '@' + Object.keys(expansionMap).length;
       expansionMap[key] = parseKeyExpression({

--- a/src/psbt.ts
+++ b/src/psbt.ts
@@ -139,6 +139,7 @@ export function updatePsbt({
   keysInfo,
   scriptPubKey,
   isSegwit,
+  isTaproot,
   witnessScript,
   redeemScript,
   rbf
@@ -153,6 +154,7 @@ export function updatePsbt({
   keysInfo: KeyInfo[];
   scriptPubKey: Buffer;
   isSegwit: boolean;
+  isTaproot: boolean;
   witnessScript: Buffer | undefined;
   redeemScript: Buffer | undefined;
   rbf: boolean;

--- a/src/re.ts
+++ b/src/re.ts
@@ -61,7 +61,7 @@ const reAddr = String.raw`addr\((.*?)\)`; //Matches anything. We assert later in
 const rePkh = String.raw`pkh\(${reNonSegwitKeyExp}\)`;
 const reWpkh = String.raw`wpkh\(${reSegwitKeyExp}\)`;
 const reShWpkh = String.raw`sh\(wpkh\(${reSegwitKeyExp}\)\)`;
-const reTrInternal = String.raw`tr\(${reTaprootKeyExp}\)`; // TODO: tr(KEY,SCRIPT) not yet supported. TrInternal used for tr(KEY)
+const reTrInternal = String.raw`tr\(${reTaprootKeyExp}\)`; // TODO: tr(KEY,TREE) not yet supported. TrInternal used for tr(KEY)
 
 const reMiniscript = String.raw`(.*?)`; //Matches anything. We assert later in the code that miniscripts are valid and sane.
 

--- a/src/re.ts
+++ b/src/re.ts
@@ -61,7 +61,7 @@ const reAddr = String.raw`addr\((.*?)\)`; //Matches anything. We assert later in
 const rePkh = String.raw`pkh\(${reNonSegwitKeyExp}\)`;
 const reWpkh = String.raw`wpkh\(${reSegwitKeyExp}\)`;
 const reShWpkh = String.raw`sh\(wpkh\(${reSegwitKeyExp}\)\)`;
-const reTrInternal = String.raw`tr\(${reTaprootKeyExp}\)`; // TODO: tr(KEY,TREE) not yet supported. TrInternal used for tr(KEY)
+const reTrSingleKey = String.raw`tr\(${reTaprootKeyExp}\)`; // TODO: tr(KEY,TREE) not yet supported. TrSingleKey used for tr(KEY)
 
 const reMiniscript = String.raw`(.*?)`; //Matches anything. We assert later in the code that miniscripts are valid and sane.
 
@@ -80,8 +80,8 @@ export const reAddrAnchored = anchorStartAndEnd(composeChecksum(reAddr));
 export const rePkhAnchored = anchorStartAndEnd(composeChecksum(rePkh));
 export const reWpkhAnchored = anchorStartAndEnd(composeChecksum(reWpkh));
 export const reShWpkhAnchored = anchorStartAndEnd(composeChecksum(reShWpkh));
-export const reTrInternalAnchored = anchorStartAndEnd(
-  composeChecksum(reTrInternal)
+export const reTrSingleKeyAnchored = anchorStartAndEnd(
+  composeChecksum(reTrSingleKey)
 );
 
 export const reShMiniscriptAnchored = anchorStartAndEnd(

--- a/src/scriptExpressions.ts
+++ b/src/scriptExpressions.ts
@@ -43,7 +43,7 @@ function standardExpressionsBIP32Maker(
     /** @default networks.bitcoin */
     network?: Network;
     account: number;
-    change?: number | undefined; //0 -> external (reveive), 1 -> internal (change)
+    change?: number | undefined; //0 -> external (receive), 1 -> internal (change)
     index?: number | undefined | '*';
     keyPath?: string;
     /**

--- a/src/scriptExpressions.ts
+++ b/src/scriptExpressions.ts
@@ -79,6 +79,7 @@ export const wpkhBIP32 = standardExpressionsBIP32Maker(
   84,
   'wpkh(KEYEXPRESSION)'
 );
+export const trBIP32 = standardExpressionsBIP32Maker(86, 'tr(KEYEXPRESSION)');
 
 function standardExpressionsLedgerMaker(
   purpose: number,
@@ -187,3 +188,4 @@ export const wpkhLedger = standardExpressionsLedgerMaker(
   84,
   'wpkh(KEYEXPRESSION)'
 );
+export const trLedger = standardExpressionsLedgerMaker(86, 'tr(KEYEXPRESSION)');

--- a/src/signers.ts
+++ b/src/signers.ts
@@ -37,16 +37,16 @@ function range(n: number): number[] {
 }
 /**
  * Signs a specific input of a PSBT with an ECPair.
- * 
+ *
  * Unlike bitcoinjs-lib's native `psbt.signInput()`, this function automatically detects
  * if the input is a Taproot input and internally tweaks the key if needed.
- * 
+ *
  * This behavior matches how `signInputBIP32` works, where the BIP32 node is automatically
  * tweaked for Taproot inputs. In contrast, bitcoinjs-lib's native implementation requires
  * manual pre-tweaking of ECPair signers for Taproot inputs.
- * 
+ *
  * @see https://github.com/bitcoinjs/bitcoinjs-lib/pull/2137#issuecomment-2713264848
- * 
+ *
  * @param {Object} params - The parameters object
  * @param {Psbt} params.psbt - The PSBT to sign
  * @param {number} params.index - The input index to sign
@@ -77,20 +77,20 @@ export function signInputECPair({
 }
 /**
  * Signs all inputs of a PSBT with an ECPair.
- * 
+ *
  * This function improves upon bitcoinjs-lib's native `psbt.signAllInputs()` by automatically
  * handling Taproot inputs. For each input, it detects if it's a Taproot input and internally
  * tweaks the key if needed.
- * 
- * This creates consistency with the BIP32 signing methods (`signBIP32`/`signInputBIP32`), 
+ *
+ * This creates consistency with the BIP32 signing methods (`signBIP32`/`signInputBIP32`),
  * which also automatically handle key tweaking for Taproot inputs. In contrast, bitcoinjs-lib's
  * native implementation requires users to manually pre-tweak ECPair signers for Taproot inputs.
- * 
+ *
  * With this implementation, you can use a single ECPair to sign both Taproot and non-Taproot
  * inputs in the same PSBT, similar to how `signBIP32` allows using a common node for both types.
- * 
+ *
  * @see https://github.com/bitcoinjs/bitcoinjs-lib/pull/2137#issuecomment-2713264848
- * 
+ *
  * @param {Object} params - The parameters object
  * @param {Psbt} params.psbt - The PSBT to sign
  * @param {ECPairInterface} params.ecpair - The ECPair to sign with

--- a/src/signers.ts
+++ b/src/signers.ts
@@ -35,6 +35,23 @@ declare class PartialSignature {
 function range(n: number): number[] {
   return [...Array(n).keys()];
 }
+/**
+ * Signs a specific input of a PSBT with an ECPair.
+ * 
+ * Unlike bitcoinjs-lib's native `psbt.signInput()`, this function automatically detects
+ * if the input is a Taproot input and internally tweaks the key if needed.
+ * 
+ * This behavior matches how `signInputBIP32` works, where the BIP32 node is automatically
+ * tweaked for Taproot inputs. In contrast, bitcoinjs-lib's native implementation requires
+ * manual pre-tweaking of ECPair signers for Taproot inputs.
+ * 
+ * @see https://github.com/bitcoinjs/bitcoinjs-lib/pull/2137#issuecomment-2713264848
+ * 
+ * @param {Object} params - The parameters object
+ * @param {Psbt} params.psbt - The PSBT to sign
+ * @param {number} params.index - The input index to sign
+ * @param {ECPairInterface} params.ecpair - The ECPair to sign with
+ */
 export function signInputECPair({
   psbt,
   index,
@@ -58,6 +75,26 @@ export function signInputECPair({
     psbt.signInput(index, tweakedEcpair);
   } else psbt.signInput(index, ecpair);
 }
+/**
+ * Signs all inputs of a PSBT with an ECPair.
+ * 
+ * This function improves upon bitcoinjs-lib's native `psbt.signAllInputs()` by automatically
+ * handling Taproot inputs. For each input, it detects if it's a Taproot input and internally
+ * tweaks the key if needed.
+ * 
+ * This creates consistency with the BIP32 signing methods (`signBIP32`/`signInputBIP32`), 
+ * which also automatically handle key tweaking for Taproot inputs. In contrast, bitcoinjs-lib's
+ * native implementation requires users to manually pre-tweak ECPair signers for Taproot inputs.
+ * 
+ * With this implementation, you can use a single ECPair to sign both Taproot and non-Taproot
+ * inputs in the same PSBT, similar to how `signBIP32` allows using a common node for both types.
+ * 
+ * @see https://github.com/bitcoinjs/bitcoinjs-lib/pull/2137#issuecomment-2713264848
+ * 
+ * @param {Object} params - The parameters object
+ * @param {Psbt} params.psbt - The PSBT to sign
+ * @param {ECPairInterface} params.ecpair - The ECPair to sign with
+ */
 export function signECPair({
   psbt,
   ecpair

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type TimeConstraints = {
  */
 export type KeyInfo = {
   keyExpression: string;
-  pubkey?: Buffer; //Must be set unless this corresponds to a ranged-descriptor
+  pubkey?: Buffer; //Must be set unless this corresponds to a ranged-descriptor. For taproot this is the 32 bytes x-only pubkey.
   ecpair?: ECPairInterface;
   bip32?: BIP32Interface;
   masterFingerprint?: Buffer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface TinySecp256k1Interface {
     p: Uint8Array,
     tweak: Uint8Array
   ): XOnlyPointAddTweakResult | null;
+  isXOnlyPoint(p: Uint8Array): boolean;
   privateNegate(d: Uint8Array): Uint8Array;
 }
 
@@ -143,6 +144,11 @@ export type Expansion = {
    * A boolean indicating whether the descriptor uses SegWit.
    */
   isSegwit?: boolean;
+
+  /**
+   * A boolean indicating whether the descriptor uses Taproot.
+   */
+  isTaproot?: boolean;
 
   /**
    * The expanded miniscript, if any.
@@ -207,6 +213,13 @@ export interface ParseKeyExpression {
      * expression) is compressed (33 bytes).
      */
     isSegwit?: boolean;
+    /**
+     * Indicates if this key expression belongs to a Taproot output.
+     * For Taproot, the key must be represented as an x-only public key
+     * (32 bytes). If a 33-byte compressed pubkey is derived, it is converted to
+     * its x-only representation.
+     */
+    isTaproot?: boolean;
     network?: Network;
   }): KeyInfo;
 }

--- a/test/bip86.test.ts
+++ b/test/bip86.test.ts
@@ -1,0 +1,28 @@
+//https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#user-content-Address_derivation
+
+import * as ecc from '@bitcoinerlab/secp256k1';
+import { networks } from 'bitcoinjs-lib';
+import { DescriptorsFactory, scriptExpressions } from '../dist/';
+import { mnemonicToSeedSync } from 'bip39';
+const { trBIP32 } = scriptExpressions;
+const { Output, BIP32 } = DescriptorsFactory(ecc);
+const network = networks.bitcoin;
+const masterNode = BIP32.fromSeed(
+  mnemonicToSeedSync(
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+  ),
+  network
+);
+describe('BIP86', () => {
+  test('BIP86', () => {
+    const descriptor = trBIP32({
+      masterNode,
+      network,
+      account: 0,
+      change: 0,
+      index: 0
+    });
+    const output = new Output({ descriptor, network });
+    console.log(output.getAddress());
+  });
+});

--- a/test/bip86.test.ts
+++ b/test/bip86.test.ts
@@ -1,4 +1,5 @@
-//https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#user-content-Address_derivation
+// BIP86: Taproot BIP32 Derivation Path and Extended Key Version
+// https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
 
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { networks } from 'bitcoinjs-lib';
@@ -13,8 +14,21 @@ const masterNode = BIP32.fromSeed(
   ),
   network
 );
-describe('BIP86', () => {
-  test('BIP86', () => {
+
+describe('BIP86 Taproot Derivation Path Tests', () => {
+  // Test vector from BIP86 specification
+  // https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#test-vectors
+  
+  test('First receiving address m/86\'/0\'/0\'/0/0', () => {
+    // Account 0, first receiving address = m/86'/0'/0'/0/0
+    // Expected values from BIP86 specification:
+    // xprv = xprvA449goEeU9okwCzzZaxiy475EQGQzBkc65su82nXEvcwzfSskb2hAt2WymrjyRL6kpbVTGL3cKtp9herYXSjjQ1j4stsXXiRF7kXkCacK3T
+    // xpub = xpub6H3W6JmYJXN49h5TfcVjLC3onS6uPeUTTJoVvRC8oG9vsTn2J8LwigLzq5tHbrwAzH9DGo6ThGUdWsqce8dGfwHVBxSbixjDADGGdzF7t2B
+    // internal_key = cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115
+    // output_key = a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c
+    // scriptPubKey = 5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c
+    // address = bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr
+    
     const descriptor = trBIP32({
       masterNode,
       network,
@@ -22,7 +36,36 @@ describe('BIP86', () => {
       change: 0,
       index: 0
     });
+    
     const output = new Output({ descriptor, network });
-    console.log(output.getAddress());
+    const address = output.getAddress();
+    const scriptPubKey = output.getScriptPubKey().toString('hex');
+    
+    // Verify the generated address matches the expected value from BIP86 spec
+    expect(address).toBe('bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr');
+    
+    // Verify the scriptPubKey matches the expected value (with 5120 prefix for OP_PUSHBYTES_32 + 32-byte key)
+    expect(scriptPubKey).toBe('5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c');
+  });
+  
+  test('Basic Taproot descriptor functionality', () => {
+    const descriptor = trBIP32({
+      masterNode,
+      network,
+      account: 0,
+      change: 0,
+      index: 0
+    });
+    
+    const output = new Output({ descriptor, network });
+    
+    // Verify we can get an address
+    expect(output.getAddress()).toBeTruthy();
+    
+    // Verify it's a Taproot address (starts with bc1p for mainnet)
+    expect(output.getAddress().startsWith('bc1p')).toBe(true);
+    
+    // Verify it's recognized as Taproot
+    expect(output.isTaproot()).toBe(true);
   });
 });

--- a/test/bip86.test.ts
+++ b/test/bip86.test.ts
@@ -1,5 +1,9 @@
+// Copyright (c) 2025 Jose-Luis Landabaso - https://bitcoinerlab.com
+// Distributed under the MIT software license
+
 // BIP86: Taproot BIP32 Derivation Path and Extended Key Version
 // https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
+// Read Interesting discussion here: https://github.com/bitcoinjs/bitcoinjs-lib/issues/1871
 
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { networks } from 'bitcoinjs-lib';
@@ -18,8 +22,8 @@ const masterNode = BIP32.fromSeed(
 describe('BIP86 Taproot Derivation Path Tests', () => {
   // Test vector from BIP86 specification
   // https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#test-vectors
-  
-  test('First receiving address m/86\'/0\'/0\'/0/0', () => {
+
+  test("First receiving address m/86'/0'/0'/0/0", () => {
     // Account 0, first receiving address = m/86'/0'/0'/0/0
     // Expected values from BIP86 specification:
     // xprv = xprvA449goEeU9okwCzzZaxiy475EQGQzBkc65su82nXEvcwzfSskb2hAt2WymrjyRL6kpbVTGL3cKtp9herYXSjjQ1j4stsXXiRF7kXkCacK3T
@@ -28,7 +32,7 @@ describe('BIP86 Taproot Derivation Path Tests', () => {
     // output_key = a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c
     // scriptPubKey = 5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c
     // address = bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr
-    
+
     const descriptor = trBIP32({
       masterNode,
       network,
@@ -36,18 +40,32 @@ describe('BIP86 Taproot Derivation Path Tests', () => {
       change: 0,
       index: 0
     });
-    
+
     const output = new Output({ descriptor, network });
     const address = output.getAddress();
     const scriptPubKey = output.getScriptPubKey().toString('hex');
-    
+    const internalKey = output.getPayment().internalPubkey?.toString('hex');
+    const pubKey = output.getPayment().pubkey?.toString('hex');
+
     // Verify the generated address matches the expected value from BIP86 spec
-    expect(address).toBe('bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr');
-    
+    expect(address).toBe(
+      'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+    );
+
     // Verify the scriptPubKey matches the expected value (with 5120 prefix for OP_PUSHBYTES_32 + 32-byte key)
-    expect(scriptPubKey).toBe('5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c');
+    expect(scriptPubKey).toBe(
+      '5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c'
+    );
+
+    expect(internalKey).toBe(
+      'cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115'
+    );
+
+    expect(pubKey).toBe(
+      'a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c'
+    );
   });
-  
+
   test('Basic Taproot descriptor functionality', () => {
     const descriptor = trBIP32({
       masterNode,
@@ -56,15 +74,15 @@ describe('BIP86 Taproot Derivation Path Tests', () => {
       change: 0,
       index: 0
     });
-    
+
     const output = new Output({ descriptor, network });
-    
+
     // Verify we can get an address
     expect(output.getAddress()).toBeTruthy();
-    
+
     // Verify it's a Taproot address (starts with bc1p for mainnet)
     expect(output.getAddress().startsWith('bc1p')).toBe(true);
-    
+
     // Verify it's recognized as Taproot
     expect(output.isTaproot()).toBe(true);
   });

--- a/test/fixtures/bitcoinCore.ts
+++ b/test/fixtures/bitcoinCore.ts
@@ -54,6 +54,19 @@ export const fixtures = {
       checksumRequired: false
     },
     {
+      descriptor: 'tr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)',
+      script:
+        '512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11',
+      checksumRequired: false
+    },
+    {
+      descriptor:
+        'tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)',
+      script:
+        '512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11',
+      checksumRequired: false
+    },
+    {
       descriptor: 'pk(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)',
       script:
         '4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235ac',

--- a/test/fixtures/custom.ts
+++ b/test/fixtures/custom.ts
@@ -538,6 +538,39 @@ export const fixtures = {
           }
         }
       }
+    },
+    {
+      note: 'Valid Taproot descriptor using an x-only public key - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor:
+        'tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)',
+      script:
+        '512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11',
+      checksumRequired: false,
+      expansion: {
+        expandedExpression: 'tr(@0)',
+        expansionMap: {
+          '@0': {
+            keyExpression:
+              'a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd'
+          }
+        }
+      }
+    },
+    {
+      note: 'Valid Taproot descriptor with WIF private key (should be converted to x-only pubkey) - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor: 'tr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)',
+      script:
+        '512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11',
+      checksumRequired: false,
+      expansion: {
+        expandedExpression: 'tr(@0)',
+        expansionMap: {
+          '@0': {
+            keyExpression:
+              'L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'
+          }
+        }
+      }
     }
   ],
   invalid: [
@@ -596,6 +629,37 @@ export const fixtures = {
         'wsh(sh(pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)))',
       checksumRequired: false,
       throw: 'Error: Miniscript sh(pk(@0)) is not sane'
+    },
+    {
+      note: 'Invalid Taproot descriptor: uncompressed public key not allowed - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor:
+        'tr(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)',
+      checksumRequired: false,
+      throw:
+        'Error: Could not parse descriptor tr(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)'
+    },
+    {
+      note: 'Invalid Taproot descriptor: tr() nested inside wsh() - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor:
+        'wsh(tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))',
+      checksumRequired: false,
+      throw:
+        'Error: Miniscript tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd) is not sane'
+    },
+    {
+      note: 'Invalid Taproot descriptor: tr() nested inside sh() - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor:
+        'sh(tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))',
+      checksumRequired: false,
+      throw: 'Error: Miniscript expressions can only be used in wsh'
+    },
+    {
+      note: 'Invalid Taproot descriptor: script path not yet supported - https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki',
+      descriptor:
+        'tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,{pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0)})',
+      checksumRequired: false,
+      throw:
+        'Error: Could not parse descriptor tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,{pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0)})'
     }
   ]
 };

--- a/test/integration/standardOutputs.ts
+++ b/test/integration/standardOutputs.ts
@@ -24,7 +24,7 @@ import {
   keyExpressionBIP32,
   signers
 } from '../../dist/';
-const { wpkhBIP32, shWpkhBIP32, pkhBIP32 } = scriptExpressions;
+const { wpkhBIP32, shWpkhBIP32, pkhBIP32, trBIP32 } = scriptExpressions;
 const { signBIP32, signECPair } = signers;
 
 const { Output, BIP32, ECPair } = DescriptorsFactory(ecc);
@@ -40,7 +40,14 @@ const expressionsBIP32 = [
   })})`,
   pkhBIP32({ masterNode, network: NETWORK, account: 0, change: 0, index: 0 }),
   wpkhBIP32({ masterNode, network: NETWORK, account: 0, change: 0, index: 0 }),
-  shWpkhBIP32({ masterNode, network: NETWORK, account: 0, change: 0, index: 0 })
+  shWpkhBIP32({
+    masterNode,
+    network: NETWORK,
+    account: 0,
+    change: 0,
+    index: 0
+  }),
+  trBIP32({ masterNode, network: NETWORK, account: 0, change: 0, index: 0 })
 ];
 if (
   pkhBIP32({ masterNode, network: NETWORK, account: 0, keyPath: '/0/0' }) !==

--- a/test/integration/standardOutputs.ts
+++ b/test/integration/standardOutputs.ts
@@ -61,7 +61,8 @@ const expressionsECPair = [
   `pk(${ecpair.publicKey.toString('hex')})`,
   `pkh(${ecpair.publicKey.toString('hex')})`,
   `wpkh(${ecpair.publicKey.toString('hex')})`,
-  `sh(wpkh(${ecpair.publicKey.toString('hex')}))`
+  `sh(wpkh(${ecpair.publicKey.toString('hex')}))`,
+  `tr(${ecpair.publicKey.slice(1, 33).toString('hex')})`
 ];
 
 (async () => {

--- a/test/tools/generateBitcoinCoreFixtures.js
+++ b/test/tools/generateBitcoinCoreFixtures.js
@@ -88,7 +88,7 @@ const parseTests = str => {
 const isSupported = parsed => {
   let supported = true;
   parsed.expressions.forEach(expression => {
-    if (expression.match(/tr\(/)) supported = false;
+    if (expression.match(/tr\(.*,.*\)/)) supported = false; // tr(KEY) supported. Disable when 2 param (contains a comma)
     if (expression.match(/^multi\(/)) supported = false; //Top-level multi not supported; It must be within sh or wsh
     if (expression.match(/combo\(/)) supported = false;
     if (expression.match(/sortedmulti\(/)) supported = false;


### PR DESCRIPTION
 This PR adds support for:
 - Single-key Taproot descriptors using the tr(KEY) format
 - Taproot addresses using addr(TAPROOT_ADDRESS) format

 The implementation allows users to create and work with Taproot outputs using either raw public keys or Taproot addresses. This extends the library's capabilities to support the latest Bitcoin transaction types.

 Documentation has been updated in the README to reflect these new features and provide usage examples.

 Note: This PR does not include support for tr(KEY,TREE) format with script paths.